### PR TITLE
Make the Makefile a bit nicer

### DIFF
--- a/Paper/.gitignore
+++ b/Paper/.gitignore
@@ -1,4 +1,7 @@
-template.pdf
+diff.pdf
+diff.tex
+Paper_old.tex
+Paper.pdf
 *.aux
 *.log
 *.out

--- a/Paper/Makefile
+++ b/Paper/Makefile
@@ -1,9 +1,9 @@
 TARGET = Paper
-DIFFVERSION = c76f4a68dd05643a7f2218d2a0d919f7d34642b0
+DIFFVERSION = ec5b098c7d94af43d6f36769d1908138a74b45a6
 
 all:
 	pdflatex $(TARGET)
-	open $(TARGET).pdf
+	if type open > /dev/null; then open $(TARGET).pdf; fi
 
 diff:
 	git show $(DIFFVERSION):Paper/$(TARGET).tex > $(TARGET)_old.tex
@@ -13,7 +13,7 @@ diff:
 	pdflatex diff
 	bibtex diff
 	pdflatex diff
-	open diff.pdf
+	if type open > /dev/null; then open diff.pdf; fi
 
 bib:
 	pdflatex $(TARGET)
@@ -21,7 +21,7 @@ bib:
 	pdflatex $(TARGET)
 	bibtex $(TARGET)
 	pdflatex $(TARGET)
-	open $(TARGET).pdf
+	if type open > /dev/null; then open $(TARGET).pdf; fi
 
 clean:
 	rm -f $(TARGET).pdf

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After changing the names (as above), you should just be able to type
 
    `make`
 
-to build your paper.  On Mac, this will also open the paper PDF (on other platforms, it doesn't do anything the command `open` doesn't exist).  Note that this command won't automatically build the bibliography; for that, you'll need to type
+to build your paper.  On Mac, this will also open the paper PDF (on other platforms, it doesn't do anything if the command `open` doesn't exist).  Note that this command won't automatically build the bibliography; for that, you'll need to type
 
    `make bib`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After changing the names (as above), you should just be able to type
 
    `make`
 
-to build your paper.  On Mac, this will also open the paper PDF (on other platforms, you may get an error that the command `open` doesn't exist...).  Note that this command won't automatically build the bibliography; for that, you'll need to type
+to build your paper.  On Mac, this will also open the paper PDF (on other platforms, it doesn't do anything the command `open` doesn't exist).  Note that this command won't automatically build the bibliography; for that, you'll need to type
 
    `make bib`
 


### PR DESCRIPTION
This PR make the following quality-of-life improvements around `Paper/Makefile`:

- only try to use the `open` command if it exists
- include all generated outputs in `Paper/.gitignore`
- set `DIFFVERSION` to a commit that exists in this repo